### PR TITLE
feat: extend ProjectManager interface with health check methods

### DIFF
--- a/internal/commands/health/commands.go
+++ b/internal/commands/health/commands.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/denkhaus/knot/v2/internal/manager"
 	"github.com/denkhaus/knot/v2/internal/shared"
+	"github.com/denkhaus/knot/v2/internal/types"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
 )
@@ -175,86 +176,26 @@ func validateAction() cli.ActionFunc {
 	}
 }
 
-// Status represents database health information (renamed from Status to avoid stuttering)
-type Status struct {
-	Healthy          bool          `json:"healthy"`
-	ConnectionActive bool          `json:"connection_active"`
-	PingLatency      time.Duration `json:"ping_latency"`
-	OpenConnections  int           `json:"open_connections"`
-	IdleConnections  int           `json:"idle_connections"`
-	InUseConnections int           `json:"in_use_connections"`
-	ErrorMessage     string        `json:"error_message,omitempty"`
-	LastChecked      time.Time     `json:"last_checked"`
-	DatabasePath     string        `json:"database_path"`
-	WALModeEnabled   bool          `json:"wal_mode_enabled"`
-	ForeignKeys      bool          `json:"foreign_keys_enabled"`
-}
-
 // performHealthCheck performs a health check using the project manager
-func performHealthCheck(ctx context.Context, projectManager manager.ProjectManager) (*Status, error) {
-	// For now, we'll implement a basic health check
-	// TODO(knot-f7r): Extend manager interface to expose repository health checks
-
-	start := time.Now()
-
-	// Test basic functionality by listing projects
-	_, err := projectManager.ListProjects(ctx)
-	latency := time.Since(start)
-
-	health := &Status{
-		LastChecked:      time.Now(),
-		PingLatency:      latency,
-		ConnectionActive: err == nil,
-		Healthy:          err == nil,
-		DatabasePath:     ".knot/knot.db", // Default path
-	}
-
-	if err != nil {
-		health.ErrorMessage = err.Error()
-		return health, err // Return the error here
-	}
-
-	return health, nil
+func performHealthCheck(ctx context.Context, projectManager manager.ProjectManager) (*types.HealthStatus, error) {
+	// Use the manager's HealthCheck method
+	return projectManager.HealthCheck(ctx)
 }
 
 // performPing performs a simple connectivity test
 func performPing(ctx context.Context, projectManager manager.ProjectManager) error {
-	// Test basic connectivity by attempting to list projects
-	_, err := projectManager.ListProjects(ctx)
-	return err
+	// Use the manager's Ping method
+	return projectManager.Ping(ctx)
 }
 
 // performValidation performs comprehensive validation
 func performValidation(ctx context.Context, projectManager manager.ProjectManager) error {
-	// Test multiple operations to validate connection
-	tests := []struct {
-		name string
-		test func() error
-	}{
-		{"List Projects", func() error {
-			_, err := projectManager.ListProjects(ctx)
-			return err
-		}},
-		{"Get Config", func() error {
-			config := projectManager.GetConfig()
-			if config == nil {
-				return fmt.Errorf("config is nil")
-			}
-			return nil
-		}},
-	}
-
-	for _, test := range tests {
-		if err := test.test(); err != nil {
-			return fmt.Errorf("%s failed: %w", test.name, err)
-		}
-	}
-
-	return nil
+	// Use the manager's ValidateConnection method
+	return projectManager.ValidateConnection(ctx)
 }
 
 // printStatus prints health status in human-readable format
-func printStatus(health *Status) {
+func printStatus(health *types.HealthStatus) {
 	fmt.Printf("Database Health Status:\n\n")
 
 	if health.Healthy {

--- a/internal/commands/health/commands_test.go
+++ b/internal/commands/health/commands_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/denkhaus/knot/v2/internal/config"
 	"github.com/denkhaus/knot/v2/internal/di"
 	"github.com/denkhaus/knot/v2/internal/logger"
 	"github.com/denkhaus/knot/v2/internal/mocks"
@@ -307,21 +306,52 @@ func Test_performHealthCheck(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	healthyStatus := &types.HealthStatus{
+		Healthy:          true,
+		ConnectionActive: true,
+		PingLatency:      10 * time.Millisecond,
+		OpenConnections:  5,
+		IdleConnections:  2,
+		InUseConnections: 3,
+		ErrorMessage:     "",
+		LastChecked:      time.Now(),
+		DatabasePath:     "test.db",
+		WALModeEnabled:   true,
+		ForeignKeys:      true,
+	}
+
+	unhealthyStatus := &types.HealthStatus{
+		Healthy:          false,
+		ConnectionActive: false,
+		PingLatency:      0,
+		OpenConnections:  0,
+		IdleConnections:  0,
+		InUseConnections: 0,
+		ErrorMessage:     "db connection failed",
+		LastChecked:      time.Now(),
+		DatabasePath:     "test.db",
+		WALModeEnabled:   false,
+		ForeignKeys:      false,
+	}
+
 	tests := []struct {
 		name                 string
-		listProjectsErr      error
+		mockHealthStatus     *types.HealthStatus
+		mockHealthErr        error
 		expectedHealthy      bool
 		expectedErrorMessage string
 	}{
 		{
 			name:                 "healthy check",
-			listProjectsErr:      nil,
+			mockHealthStatus:     healthyStatus,
+			mockHealthErr:        nil,
 			expectedHealthy:      true,
 			expectedErrorMessage: "",
 		},
 		{
 			name:                 "unhealthy check",
-			listProjectsErr:      errors.New("db connection failed"),
+			mockHealthStatus:     unhealthyStatus,
+			mockHealthErr:        nil,
 			expectedHealthy:      false,
 			expectedErrorMessage: "db connection failed",
 		},
@@ -331,9 +361,9 @@ func Test_performHealthCheck(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockMgr := mocks.NewMockProjectManager(ctrl)
 			mockMgr.EXPECT().
-				ListProjects(gomock.Any()).
-				Return([]*types.Project{}, tt.listProjectsErr)
-				// Use DI injector with mock manager
+				HealthCheck(gomock.Any()).
+				Return(tt.mockHealthStatus, tt.mockHealthErr)
+			// Use DI injector with mock manager
 			diContainer := di.NewContainer()
 			app := &cli.App{}
 			flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
@@ -354,7 +384,7 @@ func Test_performHealthCheck(t *testing.T) {
 				assert.True(t, healthStatus.Healthy)
 				assert.Empty(t, healthStatus.ErrorMessage)
 			} else {
-				require.Error(t, err)
+				require.NoError(t, err) // performHealthCheck doesn't return error for unhealthy status
 				assert.False(t, healthStatus.Healthy)
 				assert.Contains(t, healthStatus.ErrorMessage, tt.expectedErrorMessage)
 			}
@@ -369,19 +399,19 @@ func Test_performPing(t *testing.T) {
 	defer ctrl.Finish()
 
 	tests := []struct {
-		name            string
-		listProjectsErr error
-		expectedErr     bool
+		name        string
+		pingErr     error
+		expectedErr bool
 	}{
 		{
-			name:            "successful ping",
-			listProjectsErr: nil,
-			expectedErr:     false,
+			name:        "successful ping",
+			pingErr:     nil,
+			expectedErr: false,
 		},
 		{
-			name:            "failed ping",
-			listProjectsErr: errors.New("network unreachable"),
-			expectedErr:     true,
+			name:        "failed ping",
+			pingErr:     errors.New("network unreachable"),
+			expectedErr: true,
 		},
 	}
 
@@ -389,9 +419,9 @@ func Test_performPing(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockMgr := mocks.NewMockProjectManager(ctrl)
 			mockMgr.EXPECT().
-				ListProjects(gomock.Any()).
-				Return([]*types.Project{}, tt.listProjectsErr)
-				// Use DI injector with mock manager
+				Ping(gomock.Any()).
+				Return(tt.pingErr)
+			// Use DI injector with mock manager
 			diContainer := di.NewContainer()
 			app := &cli.App{}
 			flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
@@ -409,7 +439,7 @@ func Test_performPing(t *testing.T) {
 
 			if tt.expectedErr {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.listProjectsErr.Error())
+				assert.Contains(t, err.Error(), tt.pingErr.Error())
 			} else {
 				require.NoError(t, err)
 			}
@@ -423,30 +453,20 @@ func Test_performValidation(t *testing.T) {
 
 	tests := []struct {
 		name                 string
-		listProjectsErr      error
-		getConfigReturn      *config.ManagerConfig
+		validateConnErr      error
 		expectedErr          bool
 		expectedErrorMessage string
 	}{
 		{
 			name:            "successful validation",
-			listProjectsErr: nil,
-			getConfigReturn: &config.ManagerConfig{},
+			validateConnErr: nil,
 			expectedErr:     false,
 		},
 		{
-			name:                 "list projects fails",
-			listProjectsErr:      errors.New("list projects error"),
-			getConfigReturn:      &config.ManagerConfig{},
+			name:                 "validation fails",
+			validateConnErr:      errors.New("validation error"),
 			expectedErr:          true,
-			expectedErrorMessage: "List Projects failed: list projects error",
-		},
-		{
-			name:                 "get config returns nil",
-			listProjectsErr:      nil,
-			getConfigReturn:      nil,
-			expectedErr:          true,
-			expectedErrorMessage: "Get Config failed: config is nil",
+			expectedErrorMessage: "validation error",
 		},
 	}
 
@@ -456,15 +476,8 @@ func Test_performValidation(t *testing.T) {
 
 			// Set up expectations based on the test case
 			mockMgr.EXPECT().
-				ListProjects(gomock.Any()).
-				Return([]*types.Project{}, tt.listProjectsErr)
-
-			// Only expect GetConfig if ListProjects succeeds (function short-circuits on error)
-			if tt.listProjectsErr == nil {
-				mockMgr.EXPECT().
-					GetConfig().
-					Return(tt.getConfigReturn)
-			}
+				ValidateConnection(gomock.Any()).
+				Return(tt.validateConnErr)
 
 			// Use DI injector with mock manager
 			diContainer := di.NewContainer()
@@ -495,12 +508,12 @@ func Test_performValidation(t *testing.T) {
 func Test_printStatus(t *testing.T) {
 	tests := []struct {
 		name           string
-		healthStatus   *Status
+		healthStatus   *types.HealthStatus
 		expectedOutput string
 	}{
 		{
 			name: "healthy status",
-			healthStatus: &Status{
+			healthStatus: &types.HealthStatus{
 				Healthy:          true,
 				ConnectionActive: true,
 				PingLatency:      10 * time.Millisecond,
@@ -519,7 +532,7 @@ func Test_printStatus(t *testing.T) {
 		},
 		{
 			name: "unhealthy status with error",
-			healthStatus: &Status{
+			healthStatus: &types.HealthStatus{
 				Healthy:          false,
 				ConnectionActive: false,
 				PingLatency:      500 * time.Millisecond,
@@ -540,7 +553,7 @@ func Test_printStatus(t *testing.T) {
 		},
 		{
 			name: "status with connection pool and sqlite settings",
-			healthStatus: &Status{
+			healthStatus: &types.HealthStatus{
 				Healthy:          true,
 				ConnectionActive: true,
 				PingLatency:      5 * time.Millisecond,

--- a/internal/manager/interfaces.go
+++ b/internal/manager/interfaces.go
@@ -108,6 +108,11 @@ type ProjectManager interface {
 	// Utility methods
 	GetCurrentTime() time.Time
 	ResolveProjectID(ctx context.Context) (uuid.UUID, error)
+
+	// Health check operations
+	HealthCheck(ctx context.Context) (*types.HealthStatus, error)
+	Ping(ctx context.Context) error
+	ValidateConnection(ctx context.Context) error
 }
 
 // ToolSetProvider defines the interface for creating project task tool sets (not used in CLI)

--- a/internal/manager/service.go
+++ b/internal/manager/service.go
@@ -1390,3 +1390,20 @@ func (s *projectManagerImpl) HasSelectedProject(ctx context.Context) (bool, erro
 func (s *projectManagerImpl) GetCurrentTime() time.Time {
 	return time.Now()
 }
+
+// Health check operations
+
+// HealthCheck performs a comprehensive health check of the database connection
+func (s *projectManagerImpl) HealthCheck(ctx context.Context) (*types.HealthStatus, error) {
+	return s.repo.HealthCheck(ctx)
+}
+
+// Ping performs a simple connectivity test
+func (s *projectManagerImpl) Ping(ctx context.Context) error {
+	return s.repo.Ping(ctx)
+}
+
+// ValidateConnection performs a comprehensive connection validation
+func (s *projectManagerImpl) ValidateConnection(ctx context.Context) error {
+	return s.repo.ValidateConnection(ctx)
+}

--- a/internal/mocks/mock_manager.go
+++ b/internal/mocks/mock_manager.go
@@ -412,6 +412,21 @@ func (mr *MockProjectManagerMockRecorder) HasSelectedProject(ctx any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSelectedProject", reflect.TypeOf((*MockProjectManager)(nil).HasSelectedProject), ctx)
 }
 
+// HealthCheck mocks base method.
+func (m *MockProjectManager) HealthCheck(ctx context.Context) (*types.HealthStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HealthCheck", ctx)
+	ret0, _ := ret[0].(*types.HealthStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HealthCheck indicates an expected call of HealthCheck.
+func (mr *MockProjectManagerMockRecorder) HealthCheck(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheck", reflect.TypeOf((*MockProjectManager)(nil).HealthCheck), ctx)
+}
+
 // ListProjects mocks base method.
 func (m *MockProjectManager) ListProjects(ctx context.Context) ([]*types.Project, error) {
 	m.ctrl.T.Helper()
@@ -499,6 +514,20 @@ func (m *MockProjectManager) LoadConfigFromFile() error {
 func (mr *MockProjectManagerMockRecorder) LoadConfigFromFile() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadConfigFromFile", reflect.TypeOf((*MockProjectManager)(nil).LoadConfigFromFile))
+}
+
+// Ping mocks base method.
+func (m *MockProjectManager) Ping(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ping indicates an expected call of Ping.
+func (mr *MockProjectManagerMockRecorder) Ping(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockProjectManager)(nil).Ping), ctx)
 }
 
 // RemoveTaskDependency mocks base method.
@@ -779,4 +808,18 @@ func (m *MockProjectManager) UpdateTaskTitle(ctx context.Context, taskID uuid.UU
 func (mr *MockProjectManagerMockRecorder) UpdateTaskTitle(ctx, taskID, title, actor any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskTitle", reflect.TypeOf((*MockProjectManager)(nil).UpdateTaskTitle), ctx, taskID, title, actor)
+}
+
+// ValidateConnection mocks base method.
+func (m *MockProjectManager) ValidateConnection(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateConnection", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateConnection indicates an expected call of ValidateConnection.
+func (mr *MockProjectManagerMockRecorder) ValidateConnection(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateConnection", reflect.TypeOf((*MockProjectManager)(nil).ValidateConnection), ctx)
 }

--- a/internal/mocks/mock_repository_provider.go
+++ b/internal/mocks/mock_repository_provider.go
@@ -336,6 +336,21 @@ func (mr *MockRepositoryMockRecorder) HasSelectedProject(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSelectedProject", reflect.TypeOf((*MockRepository)(nil).HasSelectedProject), ctx)
 }
 
+// HealthCheck mocks base method.
+func (m *MockRepository) HealthCheck(ctx context.Context) (*types.HealthStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HealthCheck", ctx)
+	ret0, _ := ret[0].(*types.HealthStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HealthCheck indicates an expected call of HealthCheck.
+func (mr *MockRepositoryMockRecorder) HealthCheck(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HealthCheck", reflect.TypeOf((*MockRepository)(nil).HealthCheck), ctx)
+}
+
 // ListProjects mocks base method.
 func (m *MockRepository) ListProjects(ctx context.Context) ([]*types.Project, error) {
 	m.ctrl.T.Helper()
@@ -364,6 +379,20 @@ func (m *MockRepository) ListTasks(ctx context.Context, filter types.TaskFilter)
 func (mr *MockRepositoryMockRecorder) ListTasks(ctx, filter any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasks", reflect.TypeOf((*MockRepository)(nil).ListTasks), ctx, filter)
+}
+
+// Ping mocks base method.
+func (m *MockRepository) Ping(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Ping", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Ping indicates an expected call of Ping.
+func (mr *MockRepositoryMockRecorder) Ping(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockRepository)(nil).Ping), ctx)
 }
 
 // RemoveTaskDependency mocks base method.
@@ -421,6 +450,20 @@ func (m *MockRepository) UpdateTask(ctx context.Context, task *types.Task) error
 func (mr *MockRepositoryMockRecorder) UpdateTask(ctx, task any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTask", reflect.TypeOf((*MockRepository)(nil).UpdateTask), ctx, task)
+}
+
+// ValidateConnection mocks base method.
+func (m *MockRepository) ValidateConnection(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateConnection", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ValidateConnection indicates an expected call of ValidateConnection.
+func (mr *MockRepositoryMockRecorder) ValidateConnection(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateConnection", reflect.TypeOf((*MockRepository)(nil).ValidateConnection), ctx)
 }
 
 // MockRepositoryProvider is a mock of RepositoryProvider interface.

--- a/internal/mocks/mock_session_registry.go
+++ b/internal/mocks/mock_session_registry.go
@@ -115,6 +115,20 @@ func (mr *MockSessionRegistryMockRecorder) RemoveSession(ctx, sessionID any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSession", reflect.TypeOf((*MockSessionRegistry)(nil).RemoveSession), ctx, sessionID)
 }
 
+// SetSessionProject mocks base method.
+func (m *MockSessionRegistry) SetSessionProject(ctx context.Context, sessionID uuid.UUID, projectID *uuid.UUID, actor string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetSessionProject", ctx, sessionID, projectID, actor)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetSessionProject indicates an expected call of SetSessionProject.
+func (mr *MockSessionRegistryMockRecorder) SetSessionProject(ctx, sessionID, projectID, actor any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSessionProject", reflect.TypeOf((*MockSessionRegistry)(nil).SetSessionProject), ctx, sessionID, projectID, actor)
+}
+
 // SyncExistingSessions mocks base method.
 func (m *MockSessionRegistry) SyncExistingSessions(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/internal/repository/inmemory/repository.go
+++ b/internal/repository/inmemory/repository.go
@@ -500,6 +500,40 @@ func (r *simpleMemoryRepository) HasSelectedProject(ctx context.Context) (bool, 
 	return r.selectedProjectID != nil, nil
 }
 
+// Health check operations
+
+// HealthCheck performs a comprehensive health check of the in-memory repository
+func (r *simpleMemoryRepository) HealthCheck(ctx context.Context) (*types.HealthStatus, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return &types.HealthStatus{
+		Healthy:          true,
+		ConnectionActive: true,
+		PingLatency:      0,
+		OpenConnections:  1,
+		IdleConnections:  0,
+		InUseConnections: 1,
+		ErrorMessage:     "",
+		LastChecked:      time.Now(),
+		DatabasePath:     "in-memory",
+		WALModeEnabled:   false,
+		ForeignKeys:      false,
+	}, nil
+}
+
+// Ping performs a simple connectivity test
+func (r *simpleMemoryRepository) Ping(ctx context.Context) error {
+	// In-memory repository is always available
+	return nil
+}
+
+// ValidateConnection performs a comprehensive connection validation
+func (r *simpleMemoryRepository) ValidateConnection(ctx context.Context) error {
+	// In-memory repository is always valid
+	return nil
+}
+
 // Helper function to match tasks against filter
 func (r *simpleMemoryRepository) matchesFilter(task *types.Task, filter types.TaskFilter) bool {
 	if filter.ProjectID != nil && task.ProjectID != *filter.ProjectID {

--- a/internal/repository/postgres/repository.go
+++ b/internal/repository/postgres/repository.go
@@ -19,6 +19,7 @@ import (
 // postgresRepository implements the Repository interface using ent ORM with PostgreSQL
 type postgresRepository struct {
 	client    *ent.Client
+	db        *sql.DB // Store db reference for health checks
 	logger    *zap.Logger
 	dsn       string
 	autoMigrate bool
@@ -92,6 +93,7 @@ func (r *postgresRepository) initialize() error {
 	}
 
 	r.client = client
+	r.db = db // Store db reference for health checks
 	return nil
 }
 
@@ -443,16 +445,15 @@ func (r *postgresRepository) HealthCheck(ctx context.Context) (*types.HealthStat
 		DatabasePath: r.dsn,
 	}
 
-	// Get underlying database connection
-	db, err := r.getUnderlyingDB()
-	if err != nil {
-		status.ErrorMessage = fmt.Sprintf("failed to get database connection: %v", err)
+	// Check db reference
+	if r.db == nil {
+		status.ErrorMessage = "database not initialized"
 		return status, nil
 	}
 
 	// Test basic connectivity with ping
 	start := time.Now()
-	if err := db.PingContext(ctx); err != nil {
+	if err := r.db.PingContext(ctx); err != nil {
 		status.ErrorMessage = fmt.Sprintf("ping failed: %v", err)
 		return status, nil
 	}
@@ -460,13 +461,13 @@ func (r *postgresRepository) HealthCheck(ctx context.Context) (*types.HealthStat
 	status.ConnectionActive = true
 
 	// Get connection pool statistics
-	stats := db.Stats()
+	stats := r.db.Stats()
 	status.OpenConnections = stats.OpenConnections
 	status.IdleConnections = stats.Idle
 	status.InUseConnections = stats.InUse
 
 	// Test basic query execution
-	if err := r.testBasicQuery(ctx, db); err != nil {
+	if err := r.testBasicQuery(ctx); err != nil {
 		status.ErrorMessage = fmt.Sprintf("basic query test failed: %v", err)
 		return status, nil
 	}
@@ -477,12 +478,10 @@ func (r *postgresRepository) HealthCheck(ctx context.Context) (*types.HealthStat
 
 // Ping performs a simple connectivity test
 func (r *postgresRepository) Ping(ctx context.Context) error {
-	db, err := r.getUnderlyingDB()
-	if err != nil {
-		return fmt.Errorf("failed to get database connection: %w", err)
+	if r.db == nil {
+		return fmt.Errorf("database not initialized")
 	}
-
-	return db.PingContext(ctx)
+	return r.db.PingContext(ctx)
 }
 
 // ValidateConnection performs a comprehensive connection validation
@@ -513,22 +512,15 @@ func (r *postgresRepository) ValidateConnection(ctx context.Context) error {
 	return nil
 }
 
-// getUnderlyingDB extracts the underlying sql.DB from ent client
-func (r *postgresRepository) getUnderlyingDB() (*sql.DB, error) {
-	if r.client == nil {
-		return nil, fmt.Errorf("ent client not initialized")
+// testBasicQuery tests basic database functionality
+func (r *postgresRepository) testBasicQuery(ctx context.Context) error {
+	if r.db == nil {
+		return fmt.Errorf("database not initialized")
 	}
 
-	// For now, we'll use a simpler approach - test through ent client
-	// TODO: Find a way to access underlying sql.DB if needed for advanced health checks
-	return nil, fmt.Errorf("direct database access not available through ent client")
-}
-
-// testBasicQuery tests basic database functionality
-func (r *postgresRepository) testBasicQuery(ctx context.Context, db *sql.DB) error {
 	// Test a simple SELECT query
 	var result int
-	err := db.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+	err := r.db.QueryRowContext(ctx, "SELECT 1").Scan(&result)
 	if err != nil {
 		return fmt.Errorf("basic query failed: %w", err)
 	}

--- a/internal/repository/postgres/repository.go
+++ b/internal/repository/postgres/repository.go
@@ -442,7 +442,8 @@ func (r *postgresRepository) convertSessionEntToTypes(sessionEnt *ent.Session) *
 func (r *postgresRepository) HealthCheck(ctx context.Context) (*types.HealthStatus, error) {
 	status := &types.HealthStatus{
 		LastChecked:  time.Now(),
-		DatabasePath: r.dsn,
+		// Don't expose full DSN for security - it may contain credentials
+		DatabasePath: "postgresql",
 	}
 
 	// Check db reference

--- a/internal/repository/postgres/repository.go
+++ b/internal/repository/postgres/repository.go
@@ -433,3 +433,109 @@ func (r *postgresRepository) convertSessionEntToTypes(sessionEnt *ent.Session) *
 		ProjectID:    projectID,
 	}
 }
+
+// Health check operations
+
+// HealthCheck performs a comprehensive health check of the PostgreSQL connection
+func (r *postgresRepository) HealthCheck(ctx context.Context) (*types.HealthStatus, error) {
+	status := &types.HealthStatus{
+		LastChecked:  time.Now(),
+		DatabasePath: r.dsn,
+	}
+
+	// Get underlying database connection
+	db, err := r.getUnderlyingDB()
+	if err != nil {
+		status.ErrorMessage = fmt.Sprintf("failed to get database connection: %v", err)
+		return status, nil
+	}
+
+	// Test basic connectivity with ping
+	start := time.Now()
+	if err := db.PingContext(ctx); err != nil {
+		status.ErrorMessage = fmt.Sprintf("ping failed: %v", err)
+		return status, nil
+	}
+	status.PingLatency = time.Since(start)
+	status.ConnectionActive = true
+
+	// Get connection pool statistics
+	stats := db.Stats()
+	status.OpenConnections = stats.OpenConnections
+	status.IdleConnections = stats.Idle
+	status.InUseConnections = stats.InUse
+
+	// Test basic query execution
+	if err := r.testBasicQuery(ctx, db); err != nil {
+		status.ErrorMessage = fmt.Sprintf("basic query test failed: %v", err)
+		return status, nil
+	}
+
+	status.Healthy = true
+	return status, nil
+}
+
+// Ping performs a simple connectivity test
+func (r *postgresRepository) Ping(ctx context.Context) error {
+	db, err := r.getUnderlyingDB()
+	if err != nil {
+		return fmt.Errorf("failed to get database connection: %w", err)
+	}
+
+	return db.PingContext(ctx)
+}
+
+// ValidateConnection performs a comprehensive connection validation
+func (r *postgresRepository) ValidateConnection(ctx context.Context) error {
+	health, err := r.HealthCheck(ctx)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+
+	if !health.Healthy {
+		return fmt.Errorf("database connection unhealthy: %s", health.ErrorMessage)
+	}
+
+	// Additional validations
+	if health.PingLatency > time.Second {
+		r.logger.Warn("High database latency detected",
+			zap.Duration("latency", health.PingLatency))
+	}
+
+	if health.OpenConnections == 0 {
+		return fmt.Errorf("no active database connections")
+	}
+
+	r.logger.Info("Database connection validation successful",
+		zap.Duration("ping_latency", health.PingLatency),
+		zap.Int("open_connections", health.OpenConnections))
+
+	return nil
+}
+
+// getUnderlyingDB extracts the underlying sql.DB from ent client
+func (r *postgresRepository) getUnderlyingDB() (*sql.DB, error) {
+	if r.client == nil {
+		return nil, fmt.Errorf("ent client not initialized")
+	}
+
+	// For now, we'll use a simpler approach - test through ent client
+	// TODO: Find a way to access underlying sql.DB if needed for advanced health checks
+	return nil, fmt.Errorf("direct database access not available through ent client")
+}
+
+// testBasicQuery tests basic database functionality
+func (r *postgresRepository) testBasicQuery(ctx context.Context, db *sql.DB) error {
+	// Test a simple SELECT query
+	var result int
+	err := db.QueryRowContext(ctx, "SELECT 1").Scan(&result)
+	if err != nil {
+		return fmt.Errorf("basic query failed: %w", err)
+	}
+
+	if result != 1 {
+		return fmt.Errorf("unexpected query result: got %d, expected 1", result)
+	}
+
+	return nil
+}

--- a/internal/repository/sqlite/health.go
+++ b/internal/repository/sqlite/health.go
@@ -6,27 +6,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/denkhaus/knot/v2/internal/types"
 	"go.uber.org/zap"
 )
 
-// HealthStatus represents the health status of the database connection
-type HealthStatus struct {
-	Healthy          bool          `json:"healthy"`
-	ConnectionActive bool          `json:"connection_active"`
-	PingLatency      time.Duration `json:"ping_latency"`
-	OpenConnections  int           `json:"open_connections"`
-	IdleConnections  int           `json:"idle_connections"`
-	InUseConnections int           `json:"in_use_connections"`
-	ErrorMessage     string        `json:"error_message,omitempty"`
-	LastChecked      time.Time     `json:"last_checked"`
-	DatabasePath     string        `json:"database_path"`
-	WALModeEnabled   bool          `json:"wal_mode_enabled"`
-	ForeignKeys      bool          `json:"foreign_keys_enabled"`
-}
-
 // HealthCheck performs a comprehensive health check of the database connection
-func (r *sqliteRepository) HealthCheck(ctx context.Context) (*HealthStatus, error) {
-	status := &HealthStatus{
+func (r *sqliteRepository) HealthCheck(ctx context.Context) (*types.HealthStatus, error) {
+	status := &types.HealthStatus{
 		LastChecked:  time.Now(),
 		DatabasePath: r.config.DatabasePath,
 	}
@@ -136,7 +122,7 @@ func (r *sqliteRepository) testBasicQuery(ctx context.Context, db *sql.DB) error
 }
 
 // checkSQLiteSettings verifies SQLite-specific configuration
-func (r *sqliteRepository) checkSQLiteSettings(ctx context.Context, db *sql.DB, status *HealthStatus) error {
+func (r *sqliteRepository) checkSQLiteSettings(ctx context.Context, db *sql.DB, status *types.HealthStatus) error {
 	settings := []struct {
 		name     string
 		query    string

--- a/internal/repository/sqlite/health.go
+++ b/internal/repository/sqlite/health.go
@@ -17,16 +17,15 @@ func (r *sqliteRepository) HealthCheck(ctx context.Context) (*types.HealthStatus
 		DatabasePath: r.config.DatabasePath,
 	}
 
-	// Get underlying database connection
-	db, err := r.getUnderlyingDB()
-	if err != nil {
-		status.ErrorMessage = fmt.Sprintf("failed to get database connection: %v", err)
+	// Check db reference
+	if r.db == nil {
+		status.ErrorMessage = "database not initialized"
 		return status, nil
 	}
 
 	// Test basic connectivity with ping
 	start := time.Now()
-	if err := db.PingContext(ctx); err != nil {
+	if err := r.db.PingContext(ctx); err != nil {
 		status.ErrorMessage = fmt.Sprintf("ping failed: %v", err)
 		return status, nil
 	}
@@ -34,19 +33,19 @@ func (r *sqliteRepository) HealthCheck(ctx context.Context) (*types.HealthStatus
 	status.ConnectionActive = true
 
 	// Get connection pool statistics
-	stats := db.Stats()
+	stats := r.db.Stats()
 	status.OpenConnections = stats.OpenConnections
 	status.IdleConnections = stats.Idle
 	status.InUseConnections = stats.InUse
 
 	// Test basic query execution
-	if err := r.testBasicQuery(ctx, db); err != nil {
+	if err := r.testBasicQuery(ctx, r.db); err != nil {
 		status.ErrorMessage = fmt.Sprintf("basic query test failed: %v", err)
 		return status, nil
 	}
 
 	// Check SQLite-specific settings
-	if err := r.checkSQLiteSettings(ctx, db, status); err != nil {
+	if err := r.checkSQLiteSettings(ctx, r.db, status); err != nil {
 		r.config.Logger.Warn("Failed to check SQLite settings", zap.Error(err))
 		// Don't fail health check for settings check failure
 	}
@@ -57,12 +56,10 @@ func (r *sqliteRepository) HealthCheck(ctx context.Context) (*types.HealthStatus
 
 // Ping performs a simple connectivity test
 func (r *sqliteRepository) Ping(ctx context.Context) error {
-	db, err := r.getUnderlyingDB()
-	if err != nil {
-		return fmt.Errorf("failed to get database connection: %w", err)
+	if r.db == nil {
+		return fmt.Errorf("database not initialized")
 	}
-
-	return db.PingContext(ctx)
+	return r.db.PingContext(ctx)
 }
 
 // ValidateConnection performs a comprehensive connection validation
@@ -92,17 +89,6 @@ func (r *sqliteRepository) ValidateConnection(ctx context.Context) error {
 		zap.Bool("wal_mode", health.WALModeEnabled))
 
 	return nil
-}
-
-// getUnderlyingDB extracts the underlying sql.DB from ent client
-func (r *sqliteRepository) getUnderlyingDB() (*sql.DB, error) {
-	if r.client == nil {
-		return nil, fmt.Errorf("ent client not initialized")
-	}
-
-	// For now, we'll use a simpler approach - test through ent client
-	// TODO(knot-h2i): Find a way to access underlying sql.DB if needed for advanced health checks
-	return nil, fmt.Errorf("direct database access not available through ent client")
 }
 
 // testBasicQuery tests basic database functionality

--- a/internal/repository/sqlite/repository.go
+++ b/internal/repository/sqlite/repository.go
@@ -20,6 +20,7 @@ import (
 // sqliteRepository implements the Repository interface using ent ORM
 type sqliteRepository struct {
 	client *ent.Client
+	db     *sql.DB // Store db reference for health checks
 	config *Config
 	logger *zap.Logger
 }
@@ -75,6 +76,9 @@ func (r *sqliteRepository) initialize(dbPath string) error {
 	if err := r.validateInitialConnection(db); err != nil {
 		return NewConnectionError("database connection validation failed", err)
 	}
+
+	// Store db reference for health checks
+	r.db = db
 
 	// Create ent client with SQLite driver
 	drv := entsql.OpenDB(dialect.SQLite, db)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -193,6 +193,21 @@ type TaskUpdates struct {
 	Complexity *int          `json:"complexity,omitempty"`
 }
 
+// HealthStatus represents the health status of the database connection
+type HealthStatus struct {
+	Healthy          bool          `json:"healthy"`
+	ConnectionActive bool          `json:"connection_active"`
+	PingLatency      time.Duration `json:"ping_latency"`
+	OpenConnections  int           `json:"open_connections"`
+	IdleConnections  int           `json:"idle_connections"`
+	InUseConnections int           `json:"in_use_connections"`
+	ErrorMessage     string        `json:"error_message,omitempty"`
+	LastChecked      time.Time     `json:"last_checked"`
+	DatabasePath     string        `json:"database_path"`
+	WALModeEnabled   bool          `json:"wal_mode_enabled"`
+	ForeignKeys      bool          `json:"foreign_keys_enabled"`
+}
+
 // Repository defines the interface for task and project persistence and retrieval.
 //
 // This interface provides a complete abstraction layer for data storage operations,
@@ -265,6 +280,11 @@ type Repository interface {
 	SetSelectedProject(ctx context.Context, projectID uuid.UUID, actor string) error
 	ClearSelectedProject(ctx context.Context) error
 	HasSelectedProject(ctx context.Context) (bool, error)
+
+	// Health check operations
+	HealthCheck(ctx context.Context) (*HealthStatus, error)
+	Ping(ctx context.Context) error
+	ValidateConnection(ctx context.Context) error
 }
 
 // RepositoryProvider defines the interface for creating in-memory repository instances


### PR DESCRIPTION
## Summary
Extended the `ProjectManager` and `Repository` interfaces with health check methods to provide proper database health monitoring instead of using workarounds in health commands.

## Changes
- **types.go**: Added `HealthStatus` struct for shared health status reporting
- **Repository interface**: Extended with `HealthCheck()`, `Ping()`, `ValidateConnection()` methods
- **ProjectManager interface**: Extended with health check methods
- **SQLite repository**: Updated to use `types.HealthStatus` instead of local type
- **In-Memory repository**: Added health check methods (simple implementation)
- **Postgres repository**: Added health check methods (similar to SQLite)
- **Health commands**: Updated to use new interface methods instead of `ListProjects` workaround
- **Tests**: Updated all tests to use new interface methods
- **Mocks**: Regenerated to include new health methods

## Acceptance Criteria
- ✅ Extended ProjectManager interface to include health check methods
- ✅ Added HealthCheck() method to ProjectManager interface
- ✅ Added Ping() method to ProjectManager interface
- ✅ Added ValidateConnection() method to ProjectManager interface
- ✅ Implemented health check methods in project manager implementations
- ✅ Updated health commands to use new interface methods instead of workarounds
- ✅ Added proper error handling and status reporting
- ✅ All unit tests passing

## Reference
- Resolves beads issue **knot-4v3**
- Brain Memory: [brain:ee77c690-de90-4565-a14d-ad0910765428]

🤖 Generated with [Claude Code](https://claude.com/claude-code)